### PR TITLE
Removes map type information from MapAnnotation

### DIFF
--- a/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapAnnotationFactory.kt
+++ b/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapAnnotationFactory.kt
@@ -8,7 +8,7 @@ import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
 class GoogleMapAnnotationFactory : AnnotationFactory<GoogleMap> {
 
-    override fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation<GoogleMap> {
+    override fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation {
         return GoogleMapMarkerAnnotation(latLng, title, icon)
     }
 

--- a/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMarkerAnnotation.kt
+++ b/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMarkerAnnotation.kt
@@ -10,7 +10,7 @@ import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
 class GoogleMapMarkerAnnotation(latLng: LatLng,
                                 title: String?,
-                                icon: Bitmap? = null) : MarkerAnnotation<GoogleMap>(latLng, title, icon) {
+                                icon: Bitmap? = null) : MarkerAnnotation(latLng, title, icon) {
 
     override fun onUpdateIcon(icon: Bitmap?) {
         nativeMarker?.setIcon(icon?.toBitmapDescriptor())
@@ -38,12 +38,14 @@ class GoogleMapMarkerAnnotation(latLng: LatLng,
         return nativeMarker?.equals(objec) ?: false
     }
 
-    override fun removeFromMap(map: GoogleMap, context: Context) {
+    override fun removeFromMap(map: Any, context: Context) {
         nativeMarker?.remove()
         nativeMarker = null
     }
 
-    override fun addToMap(map: GoogleMap, context: Context) {
+    override fun addToMap(map: Any, context: Context) {
+        val googleMap = map as GoogleMap
+
         val options = MarkerOptions()
                 .position(latLng.toGoogleMapsLatLng())
                 .icon(icon?.toBitmapDescriptor())
@@ -51,7 +53,7 @@ class GoogleMapMarkerAnnotation(latLng: LatLng,
                 .alpha(alpha)
                 .zIndex(zIndex)
 
-        nativeMarker = map.addMarker(options)
+        nativeMarker = googleMap.addMarker(options)
     }
 
 }

--- a/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMeAdapter.kt
+++ b/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMeAdapter.kt
@@ -3,5 +3,9 @@ package nz.co.trademe.mapme.googlemaps
 import android.content.Context
 import com.google.android.gms.maps.GoogleMap
 import nz.co.trademe.mapme.MapMeAdapter
+import nz.co.trademe.mapme.annotations.MapAnnotation
+import nz.co.trademe.mapme.annotations.OnInfoWindowClickListener
 
-abstract class GoogleMapMeAdapter(context: Context) : MapMeAdapter<GoogleMap>(context, GoogleMapAnnotationFactory())
+abstract class GoogleMapMeAdapter(context: Context) : MapMeAdapter<GoogleMap>(context, GoogleMapAnnotationFactory()){
+}
+

--- a/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxAnnotationFactory.kt
+++ b/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxAnnotationFactory.kt
@@ -8,7 +8,7 @@ import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
 class MapboxAnnotationFactory : AnnotationFactory<MapboxMap> {
 
-    override fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation<MapboxMap> {
+    override fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation {
         return MapboxMarkerAnnotation(latLng, title, icon)
     }
 

--- a/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxMarkerAnnotation.kt
+++ b/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxMarkerAnnotation.kt
@@ -12,7 +12,7 @@ import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
 class MapboxMarkerAnnotation(latLng: LatLng,
                              title: String?,
-                             icon: Bitmap? = null) : MarkerAnnotation<MapboxMap>(latLng, title, icon) {
+                             icon: Bitmap? = null) : MarkerAnnotation(latLng, title, icon) {
 
 
     override fun onUpdateIcon(icon: Bitmap?) {
@@ -47,17 +47,18 @@ class MapboxMarkerAnnotation(latLng: LatLng,
         return nativeMarker?.equals(objec) ?: false
     }
 
-    override fun removeFromMap(map: MapboxMap, context: Context) {
+    override fun removeFromMap(map: Any, context: Context) {
         nativeMarker?.remove()
         nativeMarker = null
     }
 
-    override fun addToMap(map: MapboxMap, context: Context) {
+    override fun addToMap(map: Any, context: Context) {
+        val mapboxMap = map as MapboxMap
         val markerViewOptions = MarkerViewOptions()
                 .icon(icon?.toMapboxIcon(context))
                 .title(title)
                 .position(latLng.toMapBoxLatLng())
-        nativeMarker = map.addMarker(markerViewOptions)
+        nativeMarker = mapboxMap.addMarker(markerViewOptions)
     }
 
 }

--- a/mapme/src/main/java/nz/co/trademe/mapme/MapMeAdapter.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/MapMeAdapter.kt
@@ -16,7 +16,7 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
 
     var mapView: View? = null
     var map: MapType? = null
-    var annotations: ArrayList<MapAnnotation<MapType>> = ArrayList()
+    var annotations: ArrayList<MapAnnotation> = ArrayList()
     var annotationClickListener: OnMapAnnotationClickListener? = null
     var infoWindowClickListener: OnInfoWindowClickListener? = null
 
@@ -29,9 +29,9 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
         MapAdapterHelper(this, this.debug)
     }
 
-    abstract fun onCreateAnnotation(factory: AnnotationFactory<@JvmSuppressWildcards MapType>, position: Int, annotationType: Int): MapAnnotation<MapType>
+    abstract fun onCreateAnnotation(factory: AnnotationFactory<@JvmSuppressWildcards MapType>, position: Int, annotationType: Int): MapAnnotation
 
-    abstract fun onBindAnnotation(annotation: MapAnnotation<MapType>, position: Int, payload: Any?)
+    abstract fun onBindAnnotation(annotation: MapAnnotation, position: Int, payload: Any?)
 
     abstract fun getItemCount(): Int
 
@@ -51,11 +51,11 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
         this.debug = true
     }
 
-    fun setOnAnnotationClickListener(listener: OnMapAnnotationClickListener) {
+    open fun setOnAnnotationClickListener(listener: OnMapAnnotationClickListener) {
         this.annotationClickListener = listener
     }
 
-    fun setOnInfoWindowClickListener(listener: OnInfoWindowClickListener) {
+    open fun setOnInfoWindowClickListener(listener: OnInfoWindowClickListener) {
         this.infoWindowClickListener = listener
     }
 
@@ -101,7 +101,7 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
 
     }
 
-    open fun onAnnotationAdded(annotation: MapAnnotation<MapType>) {
+    open fun onAnnotationAdded(annotation: MapAnnotation) {
 
     }
 
@@ -155,13 +155,13 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
         }
     }
 
-    internal fun findAnnotationForPosition(position: Int): MapAnnotation<MapType>? {
+    internal fun findAnnotationForPosition(position: Int): MapAnnotation? {
         return annotations.find { it.position == position }
     }
 
     fun onItemsInserted(positionStart: Int, itemCount: Int) {
         for (position in positionStart until positionStart + itemCount) {
-            this.annotations.add(Placeholder<MapType>().apply { this.position = position })
+            this.annotations.add(Placeholder().apply { this.position = position })
         }
     }
 
@@ -466,7 +466,7 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
         }
     }
 
-    private fun offsetPosition(annotation: MapAnnotation<MapType>, offset: Int) {
+    private fun offsetPosition(annotation: MapAnnotation, offset: Int) {
         annotation.position += offset
     }
 

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/AnnotationFactory.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/AnnotationFactory.kt
@@ -5,7 +5,7 @@ import nz.co.trademe.mapme.LatLng
 
 interface AnnotationFactory<in Map> {
 
-    fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation<Map>
+    fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation
 
     fun clear(map: Map)
 

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/MapAnnotation.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/MapAnnotation.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import nz.co.trademe.mapme.NO_POSITION
 import java.io.Serializable
 
-abstract class MapAnnotation<in M> : Serializable {
+abstract class MapAnnotation : Serializable {
 
     var position = NO_POSITION
     var placeholder = false
@@ -12,9 +12,9 @@ abstract class MapAnnotation<in M> : Serializable {
 
     abstract fun annotatesObject(nativeObject: Any): Boolean
 
-    abstract fun addToMap(map: M, context: Context)
+    abstract fun addToMap(map: Any, context: Context)
 
-    abstract fun removeFromMap(map: M, context: Context)
+    abstract fun removeFromMap(map: Any, context: Context)
 
 }
 

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/MarkerAnnotation.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/MarkerAnnotation.kt
@@ -3,11 +3,11 @@ package nz.co.trademe.mapme.annotations
 import android.graphics.Bitmap
 import nz.co.trademe.mapme.LatLng
 
-abstract class MarkerAnnotation<in M>(latLng: LatLng,
+abstract class MarkerAnnotation(latLng: LatLng,
                                       title: String? = null,
                                       icon: Bitmap? = null,
                                       zIndex: Float = 0f,
-                                      alpha: Float = 1f) : MapAnnotation<M>() {
+                                      alpha: Float = 1f) : MapAnnotation() {
 
     var latLng: LatLng = latLng
         set(value) {

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/OnInfoWindowClickListener.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/OnInfoWindowClickListener.kt
@@ -2,6 +2,6 @@ package nz.co.trademe.mapme.annotations
 
 interface OnInfoWindowClickListener {
 
-    fun <M> onInfoWindowClick(mapAnnotationObject: MapAnnotation<M>): Boolean
+    fun onInfoWindowClick(mapAnnotationObject: MapAnnotation): Boolean
 
 }

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/OnMapAnnotationClickListener.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/OnMapAnnotationClickListener.kt
@@ -2,6 +2,6 @@ package nz.co.trademe.mapme.annotations
 
 interface OnMapAnnotationClickListener {
 
-    fun <M> onMapAnnotationClick(mapAnnotationObject: MapAnnotation<M>): Boolean
+    fun onMapAnnotationClick(mapAnnotationObject: MapAnnotation): Boolean
 
 }

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/Placeholder.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/Placeholder.kt
@@ -11,7 +11,7 @@ import android.content.Context
  * have been applied. This causes issues where createAnnotation is called with a position that is
  * out of bounds.
  */
-internal class Placeholder<in MapType> : MapAnnotation<MapType>() {
+internal class Placeholder : MapAnnotation() {
 
     init {
         this.placeholder = true
@@ -21,9 +21,9 @@ internal class Placeholder<in MapType> : MapAnnotation<MapType>() {
         return false
     }
 
-    override fun addToMap(map: MapType, context: Context) {
+    override fun addToMap(map: Any, context: Context) {
     }
 
-    override fun removeFromMap(map: MapType, context: Context) {
+    override fun removeFromMap(map: Any, context: Context) {
     }
 }

--- a/mapme/src/test/java/nz/co/trademe/mapme/util/TestAdapter.kt
+++ b/mapme/src/test/java/nz/co/trademe/mapme/util/TestAdapter.kt
@@ -19,12 +19,12 @@ open class TestAdapter(val items: List<TestItem>, myContext: Context, myFactory:
     @SuppressLint("NewApi")
     val phaser = Phaser().apply { register() }
 
-    override fun onCreateAnnotation(factory: AnnotationFactory<TestMap>, position: Int, viewType: Int): MapAnnotation<TestMap> {
+    override fun onCreateAnnotation(factory: AnnotationFactory<TestMap>, position: Int, viewType: Int): MapAnnotation {
         createCount++
         return TestAnnotation()
     }
 
-    override fun onBindAnnotation(annotation: MapAnnotation<TestMap>, position: Int, payload: Any?) {
+    override fun onBindAnnotation(annotation: MapAnnotation, position: Int, payload: Any?) {
         val testData = items[position]
         (annotation as MarkerAnnotation).zIndex = testData.zIndex
 

--- a/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotation.kt
+++ b/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotation.kt
@@ -1,15 +1,15 @@
 package nz.co.trademe.mapme.util
 
-class TestAnnotation : nz.co.trademe.mapme.annotations.MarkerAnnotation<TestMap>(nz.co.trademe.mapme.LatLng(0.0, 0.0), "", null, 0f, 1f) {
+class TestAnnotation : nz.co.trademe.mapme.annotations.MarkerAnnotation(nz.co.trademe.mapme.LatLng(0.0, 0.0), "", null, 0f, 1f) {
 
     override fun annotatesObject(nativeObject: Any): Boolean {
         return false
     }
 
-    override fun addToMap(map: TestMap, context: android.content.Context) {
+    override fun addToMap(map: Any, context: android.content.Context) {
     }
 
-    override fun removeFromMap(map: TestMap, context: android.content.Context) {
+    override fun removeFromMap(map: Any, context: android.content.Context) {
     }
 
     override fun onUpdateIcon(icon: android.graphics.Bitmap?) {

--- a/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotationFactory.kt
+++ b/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotationFactory.kt
@@ -2,7 +2,7 @@ package nz.co.trademe.mapme.util
 
 class TestAnnotationFactory : nz.co.trademe.mapme.annotations.AnnotationFactory<TestMap> {
 
-    override fun createMarker(latLng: nz.co.trademe.mapme.LatLng, icon: android.graphics.Bitmap?, title: String?): nz.co.trademe.mapme.annotations.MarkerAnnotation<TestMap> {
+    override fun createMarker(latLng: nz.co.trademe.mapme.LatLng, icon: android.graphics.Bitmap?, title: String?): nz.co.trademe.mapme.annotations.MarkerAnnotation {
         return TestAnnotation()
     }
 

--- a/sample/src/main/java/nz/co/trademe/mapme/sample/SampleMapMeAdapter.java
+++ b/sample/src/main/java/nz/co/trademe/mapme/sample/SampleMapMeAdapter.java
@@ -27,13 +27,13 @@ public class SampleMapMeAdapter<M> extends MapMeAdapter<M> {
 
     @NotNull
     @Override
-    public MapAnnotation<M> onCreateAnnotation(@NotNull AnnotationFactory<M> mapFactory, int position, int viewType) {
+    public MapAnnotation onCreateAnnotation(@NotNull AnnotationFactory<M> mapFactory, int position, int viewType) {
         MarkerData item = this.markers.get(position);
         return mapFactory.createMarker(item.getLatLng(), getIconBitmap(item), item.getTitle());
     }
 
     @Override
-    public void onBindAnnotation(@NotNull MapAnnotation<? super M> annotation, int position, Object payload) {
+    public void onBindAnnotation(@NotNull MapAnnotation annotation, int position, Object payload) {
         if (annotation instanceof MarkerAnnotation) {
             MarkerData item = this.markers.get(position);
             ((MarkerAnnotation) annotation).setIcon(getIconBitmap(item));

--- a/sample/src/main/java/nz/co/trademe/mapme/sample/activities/MapActivity.java
+++ b/sample/src/main/java/nz/co/trademe/mapme/sample/activities/MapActivity.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import nz.co.trademe.mapme.annotations.AnnotationFactory;
 import nz.co.trademe.mapme.annotations.MapAnnotation;
-import nz.co.trademe.mapme.annotations.MarkerAnnotation;
+import nz.co.trademe.mapme.annotations.OnInfoWindowClickListener;
 import nz.co.trademe.mapme.annotations.OnMapAnnotationClickListener;
 import nz.co.trademe.mapme.sample.MarkerBottomSheet;
 import nz.co.trademe.mapme.sample.MarkerData;
@@ -46,7 +46,7 @@ public abstract class MapActivity<M> extends BaseActivity implements OnMapAnnota
     abstract View getMapView();
 
     @Override
-    public <M> boolean onMapAnnotationClick(@NotNull MapAnnotation<? super M> mapAnnotation) {
+    public boolean onMapAnnotationClick(@NotNull MapAnnotation mapAnnotation) {
         Timber.d("annotation click: " + mapAnnotation);
 
         MarkerBottomSheet bottomSheetDialog = MarkerBottomSheet.newInstance(mapAnnotation);
@@ -54,7 +54,7 @@ public abstract class MapActivity<M> extends BaseActivity implements OnMapAnnota
 
         MarkerData data = markers.get(mapAnnotation.getPosition());
         data.setSelected(true);
-        mapsAdapter.notifyItemChanged(((MarkerAnnotation) mapAnnotation).getPosition());
+        mapsAdapter.notifyItemChanged(mapAnnotation.getPosition());
         return true;
     }
 


### PR DESCRIPTION
Removing the type from MapAnnotation greatly simplifies the API. The type was something the user didn’t need to know about, so isn’t required in the API.

Removing it means we have to do a cast when interacting with the map in the annotation factory, but the annotation factory is typed so this is pretty safe.