### PR TITLE
Issue #9: Improve Factory method

### DIFF
--- a/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapAnnotationFactory.kt
+++ b/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapAnnotationFactory.kt
@@ -1,6 +1,5 @@
 package nz.co.trademe.mapme.googlemaps
 
-import android.graphics.Bitmap
 import com.google.android.gms.maps.GoogleMap
 import nz.co.trademe.mapme.LatLng
 import nz.co.trademe.mapme.annotations.AnnotationFactory
@@ -8,8 +7,8 @@ import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
 class GoogleMapAnnotationFactory : AnnotationFactory<GoogleMap> {
 
-    override fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation {
-        return GoogleMapMarkerAnnotation(latLng, title, icon)
+    override fun createMarker(latLng: LatLng): MarkerAnnotation {
+        return GoogleMapMarkerAnnotation(latLng)
     }
 
     override fun clear(map: GoogleMap) {

--- a/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMarkerAnnotation.kt
+++ b/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMarkerAnnotation.kt
@@ -8,9 +8,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 import nz.co.trademe.mapme.LatLng
 import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
-class GoogleMapMarkerAnnotation(latLng: LatLng,
-                                title: String?,
-                                icon: Bitmap? = null) : MarkerAnnotation(latLng, title, icon) {
+class GoogleMapMarkerAnnotation(latLng: LatLng) : MarkerAnnotation(latLng) {
 
     override fun onUpdateIcon(icon: Bitmap?) {
         nativeMarker?.setIcon(icon?.toBitmapDescriptor())

--- a/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxAnnotationFactory.kt
+++ b/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxAnnotationFactory.kt
@@ -1,6 +1,5 @@
 package nz.co.trademe.mapme.mapbox
 
-import android.graphics.Bitmap
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import nz.co.trademe.mapme.LatLng
 import nz.co.trademe.mapme.annotations.AnnotationFactory
@@ -8,8 +7,8 @@ import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
 class MapboxAnnotationFactory : AnnotationFactory<MapboxMap> {
 
-    override fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation {
-        return MapboxMarkerAnnotation(latLng, title, icon)
+    override fun createMarker(latLng: LatLng): MarkerAnnotation {
+        return MapboxMarkerAnnotation(latLng)
     }
 
     override fun clear(map: MapboxMap) {

--- a/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxMarkerAnnotation.kt
+++ b/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxMarkerAnnotation.kt
@@ -10,10 +10,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap
 import nz.co.trademe.mapme.LatLng
 import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
-class MapboxMarkerAnnotation(latLng: LatLng,
-                             title: String?,
-                             icon: Bitmap? = null) : MarkerAnnotation(latLng, title, icon) {
-
+class MapboxMarkerAnnotation(latLng: LatLng) : MarkerAnnotation(latLng) {
 
     override fun onUpdateIcon(icon: Bitmap?) {
         nativeMarker?.let {

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/AnnotationFactory.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/AnnotationFactory.kt
@@ -1,11 +1,10 @@
 package nz.co.trademe.mapme.annotations
 
-import android.graphics.Bitmap
 import nz.co.trademe.mapme.LatLng
 
 interface AnnotationFactory<in Map> {
 
-    fun createMarker(latLng: LatLng, icon: Bitmap?, title: String?): MarkerAnnotation
+    fun createMarker(latLng: LatLng): MarkerAnnotation
 
     fun clear(map: Map)
 

--- a/mapme/src/main/java/nz/co/trademe/mapme/annotations/MarkerAnnotation.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/annotations/MarkerAnnotation.kt
@@ -3,11 +3,7 @@ package nz.co.trademe.mapme.annotations
 import android.graphics.Bitmap
 import nz.co.trademe.mapme.LatLng
 
-abstract class MarkerAnnotation(latLng: LatLng,
-                                      title: String? = null,
-                                      icon: Bitmap? = null,
-                                      zIndex: Float = 0f,
-                                      alpha: Float = 1f) : MapAnnotation() {
+abstract class MarkerAnnotation(latLng: LatLng) : MapAnnotation() {
 
     var latLng: LatLng = latLng
         set(value) {
@@ -15,25 +11,25 @@ abstract class MarkerAnnotation(latLng: LatLng,
             onUpdatePosition(value)
         }
 
-    var title: String? = title
+    var title: String? = null
         set(value) {
             field = value
             onUpdateTitle(value)
         }
 
-    var icon: Bitmap? = icon
+    var icon: Bitmap? = null
         set(value) {
             field = value
             onUpdateIcon(value)
         }
 
-    var zIndex: Float = zIndex
+    var zIndex: Float = 0f
         set(value) {
             field = value
             onUpdateZIndex(value)
         }
 
-    var alpha: Float = alpha
+    var alpha: Float = 1f
         set(value) {
             field = value
             onUpdateAlpha(value)

--- a/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotation.kt
+++ b/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotation.kt
@@ -1,6 +1,9 @@
 package nz.co.trademe.mapme.util
 
-class TestAnnotation : nz.co.trademe.mapme.annotations.MarkerAnnotation(nz.co.trademe.mapme.LatLng(0.0, 0.0), "", null, 0f, 1f) {
+import nz.co.trademe.mapme.LatLng
+import nz.co.trademe.mapme.annotations.MarkerAnnotation
+
+class TestAnnotation : MarkerAnnotation(LatLng(0.0, 0.0)) {
 
     override fun annotatesObject(nativeObject: Any): Boolean {
         return false

--- a/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotationFactory.kt
+++ b/mapme/src/test/java/nz/co/trademe/mapme/util/TestAnnotationFactory.kt
@@ -1,8 +1,12 @@
 package nz.co.trademe.mapme.util
 
-class TestAnnotationFactory : nz.co.trademe.mapme.annotations.AnnotationFactory<TestMap> {
+import nz.co.trademe.mapme.LatLng
+import nz.co.trademe.mapme.annotations.AnnotationFactory
+import nz.co.trademe.mapme.annotations.MarkerAnnotation
 
-    override fun createMarker(latLng: nz.co.trademe.mapme.LatLng, icon: android.graphics.Bitmap?, title: String?): nz.co.trademe.mapme.annotations.MarkerAnnotation {
+class TestAnnotationFactory : AnnotationFactory<TestMap> {
+
+    override fun createMarker(latLng: LatLng): MarkerAnnotation {
         return TestAnnotation()
     }
 

--- a/sample/src/main/java/nz/co/trademe/mapme/sample/SampleMapMeAdapter.java
+++ b/sample/src/main/java/nz/co/trademe/mapme/sample/SampleMapMeAdapter.java
@@ -29,7 +29,7 @@ public class SampleMapMeAdapter<M> extends MapMeAdapter<M> {
     @Override
     public MapAnnotation onCreateAnnotation(@NotNull AnnotationFactory<M> mapFactory, int position, int viewType) {
         MarkerData item = this.markers.get(position);
-        return mapFactory.createMarker(item.getLatLng(), getIconBitmap(item), item.getTitle());
+        return mapFactory.createMarker(item.getLatLng());
     }
 
     @Override
@@ -37,6 +37,7 @@ public class SampleMapMeAdapter<M> extends MapMeAdapter<M> {
         if (annotation instanceof MarkerAnnotation) {
             MarkerData item = this.markers.get(position);
             ((MarkerAnnotation) annotation).setIcon(getIconBitmap(item));
+            ((MarkerAnnotation) annotation).setTitle(item.getTitle());
         }
     }
 


### PR DESCRIPTION
Only accept the position of the marker so the onCreateAnnotation is
clearer and does not duplicate the work that should be done in
onBindAnnotation. That simplifies the adapter and avoid possible
duplication of work and resources.