### PR TITLE
Replaces Bintray gradle plugin with maven-publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Change Log
 ==========
 
+Version 1.0.6 *(1-05-2018)*
+----------------------------
+
+ * Removes Bintray gradle plugin in favour of `maven-publishing` 
+
 Version 1.0.5 *(13-04-2018)*
+----------------------------
 
   * Updates to AGP and dependencies
   * Fixes crash when notifyDataSetChanged called multiple times

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Download
 
 ```groovy
 //base dependency
-compile 'nz.co.trademe.mapme:mapme:1.0.5'
+compile 'nz.co.trademe.mapme:mapme:1.0.6'
   
 //for Google Maps support
-compile 'nz.co.trademe.mapme:googlemaps:1.0.5'
+compile 'nz.co.trademe.mapme:googlemaps:1.0.6'
   
 //for Mapbox support
-compile 'nz.co.trademe.mapme:mapbox:1.0.5'
+compile 'nz.co.trademe.mapme:mapbox:1.0.6'
 
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$gradle_version"
+        classpath "digital.wup:android-maven-publish:$android_maven_version"
     }
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -1,5 +1,7 @@
-ext.version = "1.0.5"
+ext.version = "1.0.6"
 ext.group = "nz.co.trademe.mapme"
+ext.repo = "MapMe"
+ext.org = "trademe"
 ext.scm = 'https://github.com/TradeMe/MapMe.git'
 ext.description = 'MapMe is an Android library that brings the adapter pattern to Maps, simplifying the management of markers and annotations.'
 
@@ -7,10 +9,10 @@ ext.compileSdk = 27
 ext.minSdk = 15
 ext.buildTools = "27.0.3"
 ext.kotlin_version = '1.2.31'
-ext.bintray_version = '1.7.3'
 ext.dokka_version = '0.9.15'
 ext.gradle_version = '3.1.0'
 ext.mapbox_version = '5.1.3'
 ext.google_play_services_version = '11.8.0'
 ext.android_support_version = '27.0.1'
+ext.android_maven_version = '3.3.0'
 

--- a/googlemaps/build.gradle
+++ b/googlemaps/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintray_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,7 @@ org.gradle.jvmargs=-Xmx1536m
 #error will be removed in 3.1.0
 #See https://d.android.com/r/tools/buildscript-classpath-check.html
 android.enableBuildScriptClasspathCheck=false
+
+# Bintray credentials - When publishing, ensure changes to this file are not added to source control
+BINTRAY_USERNAME=INSERT_USERNAME_HERE
+BINTRAY_API_KEY=INSERT_KEY_HERE

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/mapbox/build.gradle
+++ b/mapbox/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintray_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/mapme/build.gradle
+++ b/mapme/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintray_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,116 +1,37 @@
-apply plugin: 'maven-publish'
-apply plugin: 'com.jfrog.bintray'
+if (project.plugins.hasPlugin("com.android.library")) {
 
-project.afterEvaluate {
-    if (project.plugins.hasPlugin("com.android.library")) {
+    apply plugin: 'digital.wup.android-maven-publish'
 
-        project.android.libraryVariants.all { variant ->
-            variant.outputs.all {
-                def newName = "${project.name}-v${project.version}.aar"
-                outputFileName = newName
+    project.afterEvaluate {
+        task sourcesJar(type: Jar) {
+            from android.sourceSets.main.java.srcDirs
+        }
+    }
+
+    publishing {
+        publications {
+            aar(MavenPublication) {
+                from project.components.android
+                artifact project.sourcesJar {
+                    // not required, includes sourcesJar with correct classifier
+                    classifier "sources"
+                }
+                groupId project.group
+                artifactId project.name
+                version project.ext.version
             }
         }
-    }
-}
 
-project.group = project.ext.group
-project.version = project.ext.version
+        repositories {
+            maven {
+                name 'Bintray'
+                url "https://api.bintray.com/maven/${project.org}/${project.repo}/${project.name}/;publish=1"
 
-bintray {
-    user = project.hasProperty("BINTRAY_USERNAME") ? project.property('BINTRAY_USERNAME') : null
-    key = project.hasProperty("BINTRAY_API_KEY") ? project.property('BINTRAY_API_KEY') : null
-    pkg {
-        repo = 'MapMe'
-        name = getArtifactId()
-        userOrg = 'trademe'
-        licenses = ['Apache-2.0']
-        vcsUrl = project.ext.scm
-        version {
-            name = project.version
-            desc = project.ext.description
-            released = new Date()
-            vcsTag = project.version
-        }
-        publications = ['Bintray']
-    }
-}
-
-// Create the pom configuration:
-def pomConfig = {
-    licenses {
-        license {
-            name "MIT License"
-            url "http://www.opensource.org/licenses/mit-license.php"
-            distribution "repo"
-        }
-    }
-    scm {
-        url ext.scm
-    }
-}
-
-//create a jar from source files
-task sourceJar(type: Jar) {
-    if (project.plugins.hasPlugin("com.android.library")) {
-        from android.sourceSets.main.java.srcDirs
-        classifier "sources"
-    }
-}
-
-publishing.publications {
-    Bintray(MavenPublication) {
-        groupId project.ext.group
-        artifactId getArtifactId()
-        version project.ext.version
-
-        artifact sourceJar
-        artifact "$buildDir/outputs/aar/${project.name}-v${project.version}.aar"
-
-        //generate pom nodes for dependencies
-        //when a project references another project, it's artifact node is generated
-        pom.withXml {
-            def root = asNode()
-            root.appendNode('description', project.ext.description)
-            root.appendNode('name', project.ext.name)
-            root.appendNode('url', project.ext.scm)
-            root.children().last() + pomConfig
-
-            def dependenciesNode = root.appendNode('dependencies')
-
-            configurations.compile.allDependencies.each { dependency ->
-                if (dependency.group != null && dependency.name != null) {
-
-                    if (dependency instanceof ProjectDependency) {
-                        dependency.getDependencyProject().getArtifacts().each { artifact ->
-                            addDependencyNodeToPom(dependenciesNode, dependency.group, getArtifactId(dependency.dependencyProject), dependency.version)
-                        }
-                    } else {
-                        addDependencyNodeToPom(dependenciesNode, dependency.group, dependency.name, dependency.version)
-                    }
+                credentials {
+                    username BINTRAY_USERNAME
+                    password BINTRAY_API_KEY
                 }
             }
         }
     }
-}
-
-def getArtifactId() {
-    return getArtifactId(project)
-
-}
-
-def getArtifactId(someProject) {
-    if (!someProject.ext.has('artifactId')) {
-        //default artifactId is the project/module name
-        return someProject.getName();
-
-    }
-    return someProject.ext.artifactId;
-}
-
-
-def addDependencyNodeToPom(dependenciesNode, group, artifact, version) {
-    def dependencyNode = dependenciesNode.appendNode('dependency')
-    dependencyNode.appendNode("groupId", group)
-    dependencyNode.appendNode("artifactId", artifact)
-    dependencyNode.appendNode("version", version)
 }


### PR DESCRIPTION
This PR replaces the Bintray gradle plugin in favour of using the significantly more simple [maven-publishing](https://docs.gradle.org/current/userguide/publishing_maven.html) plugin.