### PR TITLE
Add List adapters for simpler integration with DiffUtil

### DIFF
--- a/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMeListAdapter.kt
+++ b/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMeListAdapter.kt
@@ -1,0 +1,14 @@
+package nz.co.trademe.mapme.googlemaps
+
+import android.content.Context
+import androidx.recyclerview.widget.AsyncDifferConfig
+import androidx.recyclerview.widget.DiffUtil
+import com.google.android.gms.maps.GoogleMap
+import nz.co.trademe.mapme.MapMeListAdapter
+
+abstract class GoogleMapMeListAdapter<T>(context: Context, config: AsyncDifferConfig<T>)
+    : MapMeListAdapter<T, GoogleMap>(context, GoogleMapAnnotationFactory(), config) {
+
+    constructor(context: Context, diffCallback: DiffUtil.ItemCallback<T>)
+            : this(context, AsyncDifferConfig.Builder(diffCallback).build())
+}

--- a/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxMapMeListAdapter.kt
+++ b/mapbox/src/main/java/nz/co/trademe/mapme/mapbox/MapboxMapMeListAdapter.kt
@@ -1,0 +1,14 @@
+package nz.co.trademe.mapme.mapbox
+
+import android.content.Context
+import androidx.recyclerview.widget.AsyncDifferConfig
+import androidx.recyclerview.widget.DiffUtil
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import nz.co.trademe.mapme.MapMeListAdapter
+
+abstract class MapboxMapMeListAdapter<T>(context: Context, config: AsyncDifferConfig<T>)
+    : MapMeListAdapter<T, MapboxMap>(context, MapboxAnnotationFactory(), config) {
+
+    constructor(context: Context, diffCallback: DiffUtil.ItemCallback<T>)
+            : this(context, AsyncDifferConfig.Builder(diffCallback).build())
+}

--- a/mapme/src/main/java/nz/co/trademe/mapme/MapMeListAdapter.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/MapMeListAdapter.kt
@@ -1,0 +1,25 @@
+package nz.co.trademe.mapme
+
+import android.content.Context
+import androidx.recyclerview.widget.AsyncDifferConfig
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
+import nz.co.trademe.mapme.annotations.AnnotationFactory
+
+abstract class MapMeListAdapter<T, MapType>(context: Context, factory: AnnotationFactory<MapType>, config: AsyncDifferConfig<T>)
+    : MapMeAdapter<MapType>(context, factory) {
+
+    @Suppress("LeakingThis")
+    private val helper: AsyncListDiffer<T> = AsyncListDiffer(this, config)
+
+    constructor(context: Context, factory: AnnotationFactory<MapType>, diffCallback: DiffUtil.ItemCallback<T>)
+            : this(context, factory, AsyncDifferConfig.Builder(diffCallback).build())
+
+    fun submitList(list: List<T>?) {
+        helper.submitList(list)
+    }
+
+    protected fun getItem(position: Int): T = helper.currentList[position]
+
+    override fun getItemCount(): Int = helper.currentList.size
+}


### PR DESCRIPTION
Since DiffUtil is usually used quite heavily with this library, I thought it might be useful to add an adapter with an interface similar to [`ListAdapter`](https://developer.android.com/reference/android/support/v7/recyclerview/extensions/ListAdapter) which greatly simplifies doing asynchronous diffs for an adapter.

This implementation is based on `ListAdapter` and uses the [`AsyncListDiffer`](https://developer.android.com/reference/androidx/recyclerview/widget/AsyncListDiffer.html) class to perform the diff and dispatch it to the adapter.

Some tests still need to be written.