### PR TITLE
`attach` now accepts a nullable `View` as it internally is used safely

### DIFF
--- a/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMeAdapter.kt
+++ b/googlemaps/src/main/java/nz/co/trademe/mapme/googlemaps/GoogleMapMeAdapter.kt
@@ -3,9 +3,7 @@ package nz.co.trademe.mapme.googlemaps
 import android.content.Context
 import com.google.android.gms.maps.GoogleMap
 import nz.co.trademe.mapme.MapMeAdapter
-import nz.co.trademe.mapme.annotations.MapAnnotation
-import nz.co.trademe.mapme.annotations.OnInfoWindowClickListener
 
-abstract class GoogleMapMeAdapter(context: Context) : MapMeAdapter<GoogleMap>(context, GoogleMapAnnotationFactory()){
-}
-
+abstract class GoogleMapMeAdapter(
+        context: Context
+) : MapMeAdapter<GoogleMap>(context, GoogleMapAnnotationFactory())

--- a/mapme/src/main/java/nz/co/trademe/mapme/MapMeAdapter.kt
+++ b/mapme/src/main/java/nz/co/trademe/mapme/MapMeAdapter.kt
@@ -35,7 +35,7 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
 
     abstract fun getItemCount(): Int
 
-    fun attach(mapView: View, map: MapType) {
+    fun attach(mapView: View?, map: MapType) {
         this.map = map
         this.mapView = mapView
         this.factory.setOnMarkerClickListener(map, { marker -> notifyAnnotatedMarkerClicked(marker) })
@@ -516,7 +516,7 @@ abstract class MapMeAdapter<MapType>(var context: Context, var factory: Annotati
     }
 
     @VisibleForTesting
-    open internal fun triggerUpdateProcessor(runnable: Runnable) {
+    internal open fun triggerUpdateProcessor(runnable: Runnable) {
         mapView?.post(runnable)
     }
 


### PR DESCRIPTION
The `mapView`  is treated as `Nullable` throughout `MapMeAdapter` but when attaching, only a `NonNull View` is accepted. Even as `SupportMapFragment` is inflated in a parent's `onCreateView`, upon configuration changes `onMapReady` might be called before `onCreateView` of the parent so if the attaching is done in `onMapReady` the only possible valid `View` to pass is the one fetched by `requireView()` but that `View` has yet not been created and an `IllegalException` will be thrown.

Instead if `getView()` that is `Nullable` would be allowed, things would work out.